### PR TITLE
Update Retrofit to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ double longitude = -74.7829;
 ForecastClient.getInstance()
                     .getForecast(latitude, longitude, new Callback<Forecast>() {
                         @Override
-                        public void onResponse(Response<Forecast> response) {
+                        public void onResponse(Call<Forecast> forecastCall, Response<Forecast> response) {
                             if (response.isSuccess()) {
                                 Forecast forecast = response.body();
                             }
                         }
 
                         @Override
-                        public void onFailure(Throwable t) {
+                        public void onFailure(Call<Forecast> forecastCall, Throwable t) {
 
                         }
                     });

--- a/app/src/main/java/android/zetterstrom/com/snow/utils/SnowHelper.java
+++ b/app/src/main/java/android/zetterstrom/com/snow/utils/SnowHelper.java
@@ -27,6 +27,7 @@ import android.zetterstrom.com.snow.callbacks.ForecastCallback;
 
 import java.util.ArrayList;
 
+import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
@@ -64,8 +65,8 @@ public class SnowHelper {
             ForecastClient.getInstance()
                     .getForecast(forecastLatitude, forecastLongitude, new Callback<Forecast>() {
                         @Override
-                        public void onResponse(Response<Forecast> response) {
-                            if (response.isSuccess()) {
+                        public void onResponse(Call<Forecast> forecastCall, Response<Forecast> response) {
+                            if (response.isSuccessful()) {
                                 callback.onForecastSuccess(response.body());
                             } else {
                                 callback.onForecastError(null);
@@ -73,7 +74,7 @@ public class SnowHelper {
                         }
 
                         @Override
-                        public void onFailure(Throwable t) {
+                        public void onFailure(Call<Forecast> forecastCall, Throwable t) {
                             callback.onForecastError(t);
                         }
                     });

--- a/forecast/build.gradle
+++ b/forecast/build.gradle
@@ -45,8 +45,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'com.squareup.retrofit2:retrofit:2.0.0-beta3'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0-beta3'
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/forecast/src/main/java/android/zetterstrom/com/forecast/ForecastClient.java
+++ b/forecast/src/main/java/android/zetterstrom/com/forecast/ForecastClient.java
@@ -43,9 +43,9 @@ import okhttp3.CacheControl;
 import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Callback;
-import retrofit2.GsonConverterFactory;
 import retrofit2.Response;
 import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * Singleton class for interacting with the Forecast.io API


### PR DESCRIPTION
Fix conflicts with the GsonConverterFactory changing their namespace from retrofit2.GsonConverterFactory (2.0.0-beta3) to retrofit2.converter.gson.GsonConverterFactory (2.1.x)